### PR TITLE
Add second TeamCity agent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,13 @@ services:
     volumes:
       - ./data/teamcity_agent/conf:/data/teamcity_agent/conf
       - /var/run/docker.sock:/var/run/docker.sock
+
+  teamcity-agent-2:
+    image: jetbrains/teamcity-agent:latest
+    container_name: teamcity-agent-2
+    user: root
+    environment:
+      - SERVER_URL=http://teamcity-server:8111
+    volumes:
+      - ./data/teamcity_agent_2/conf:/data/teamcity_agent/conf
+      - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
## Summary
- add a second TeamCity agent container in docker-compose

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896f40e3ba48323903e8db72564b5cc